### PR TITLE
Feat accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "json-server": "^0.17.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.8.2"
       },
       "devDependencies": {
         "@types/node": "^18.14.1",
@@ -773,6 +774,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
+      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@types/node": {
@@ -2122,6 +2131,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
+      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "dependencies": {
+        "@remix-run/router": "1.3.3"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
+      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "dependencies": {
+        "@remix-run/router": "1.3.3",
+        "react-router": "6.8.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3028,6 +3067,11 @@
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
+    },
+    "@remix-run/router": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.3.3.tgz",
+      "integrity": "sha512-YRHie1yQEj0kqqCTCJEfHqYSSNlZQ696QJG+MMiW4mxSl9I0ojz/eRhJS4fs88Z5i6D1SmoF9d3K99/QOhI8/w=="
     },
     "@types/node": {
       "version": "18.14.1",
@@ -4041,6 +4085,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.8.2.tgz",
+      "integrity": "sha512-lF7S0UmXI5Pd8bmHvMdPKI4u4S5McxmHnzJhrYi9ZQ6wE+DA8JN5BzVC5EEBuduWWDaiJ8u6YhVOCmThBli+rw==",
+      "requires": {
+        "@remix-run/router": "1.3.3"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.8.2.tgz",
+      "integrity": "sha512-N/oAF1Shd7g4tWy+75IIufCGsHBqT74tnzHQhbiUTYILYF0Blk65cg+HPZqwC+6SqEyx033nKqU7by38v3lBZg==",
+      "requires": {
+        "@remix-run/router": "1.3.3",
+        "react-router": "6.8.2"
+      }
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "json-server": "^0.17.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.8.2"
   },
   "devDependencies": {
     "@types/node": "^18.14.1",

--- a/reseed-db.js
+++ b/reseed-db.js
@@ -7,6 +7,11 @@ const data = {
       email: "person@example.com",
       password: "password1234",
     },
+    {
+      id: 2,
+      email: "sally.jones@site.com",
+      password: "catsRock",
+    },
   ],
   portionRows: [
     {
@@ -32,6 +37,21 @@ const data = {
     {
       id: 5,
       fdcId: 2345004,
+      fractionOfServing: 1,
+    },
+    {
+      id: 6,
+      fdcId: 2193119,
+      fractionOfServing: 0.5,
+    },
+    {
+      id: 7,
+      fdcId: 2343697,
+      fractionOfServing: 1,
+    },
+    {
+      id: 8,
+      fdcId: 1602525,
       fractionOfServing: 1,
     },
   ],
@@ -61,6 +81,21 @@ const data = {
       daySectionId: 4,
       portionRowId: 5,
     },
+    {
+      id: 6,
+      daySectionId: 5,
+      portionRowId: 6,
+    },
+    {
+      id: 7,
+      daySectionId: 5,
+      portionRowId: 7,
+    },
+    {
+      id: 8,
+      daySectionId: 6,
+      portionRowId: 8,
+    },
   ],
   daySections: [
     {
@@ -83,6 +118,16 @@ const data = {
       dayId: 3,
       indexInDay: 0,
     },
+    {
+      id: 5,
+      dayId: 4,
+      indexInDay: 4,
+    },
+    {
+      id: 6,
+      dayId: 5,
+      indexInDay: 1,
+    },
   ],
   dayChartDays: [
     {
@@ -100,12 +145,35 @@ const data = {
       dayChartId: 1,
       indexInChart: 3,
     },
+    {
+      id: 4,
+      dayChartId: 2,
+      indexInChart: 0,
+    },
+    {
+      id: 5,
+      dayChartId: 2,
+      indexInChart: 1,
+    },
+  ],
+  dayCharts: [
+    {
+      id: 1,
+    },
+    {
+      id: 2,
+    },
   ],
   userDayCharts: [
     {
       id: 1,
-      userEmail: "person@example.com",
+      userId: 1,
       dayChartId: 1,
+    },
+    {
+      id: 2,
+      userId: 2,
+      dayChartId: 2,
     },
   ],
 };

--- a/reseed-db.js
+++ b/reseed-db.js
@@ -12,6 +12,11 @@ const data = {
       email: "sally.jones@site.com",
       password: "catsRock",
     },
+    {
+      id: 3,
+      email: "rick.grimes@alexandria.com",
+      password: "cowboy",
+    },
   ],
   portionRows: [
     {
@@ -177,11 +182,5 @@ const data = {
     },
   ],
 };
-
-//to put a portion in:
-//add the portion to portionRows with correct data (keep track of the id of new portionRow)
-//add a daychartday with the dayId of that day, if there isn't one already
-//add a daySection with dayId=this day and indexInDay=the position in day desired (ONLY if there is not already a daySection with the same two values)
-//add a daySectionRow with daySectionId=(id of daySection just added) and portionRowId=(id stored from first step)
 
 writeFileSync("db.json", JSON.stringify(data), { encoding: "utf-8" });

--- a/src/App.css
+++ b/src/App.css
@@ -19,3 +19,7 @@ body {
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.492);
 }
+
+.error-text {
+  color: red;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,29 @@
+import { Routes } from "react-router";
+import { Route } from "react-router-dom";
 import "./App.css";
+import { CreateAccount } from "./components/Account/CreateAccount/CreateAccount";
+import { SignIn } from "./components/Account/SignIn/SignIn";
 import { DayChartProvider } from "./components/DayChartProvider";
 import { DayChart } from "./components/Planner/DayChart/DayChart";
 
 function App() {
   return (
     <div className="App">
-      <DayChartProvider>
+      <Routes>
+        <Route path="/" element={<SignIn />} />
+        <Route path="/createAccount" element={<CreateAccount />} />
+        <Route
+          path="/chart"
+          element={
+            <DayChartProvider>
+              <DayChart />
+            </DayChartProvider>
+          }
+        />
+      </Routes>
+      {/* <DayChartProvider>
         <DayChart />
-      </DayChartProvider>
+      </DayChartProvider> */}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,27 +3,27 @@ import { Route } from "react-router-dom";
 import "./App.css";
 import { CreateAccount } from "./components/Account/CreateAccount/CreateAccount";
 import { SignIn } from "./components/Account/SignIn/SignIn";
+import { AccountProvider } from "./components/AccountProvider";
 import { DayChartProvider } from "./components/DayChartProvider";
 import { DayChart } from "./components/Planner/DayChart/DayChart";
 
 function App() {
   return (
     <div className="App">
-      <Routes>
-        <Route path="/" element={<SignIn />} />
-        <Route path="/createAccount" element={<CreateAccount />} />
-        <Route
-          path="/chart"
-          element={
-            <DayChartProvider>
-              <DayChart />
-            </DayChartProvider>
-          }
-        />
-      </Routes>
-      {/* <DayChartProvider>
-        <DayChart />
-      </DayChartProvider> */}
+      <AccountProvider>
+        <Routes>
+          <Route path="/" element={<SignIn />} />
+          <Route path="/createAccount" element={<CreateAccount />} />
+          <Route
+            path="/chart"
+            element={
+              <DayChartProvider>
+                <DayChart />
+              </DayChartProvider>
+            }
+          />
+        </Routes>
+      </AccountProvider>
     </div>
   );
 }

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,28 @@
+import { fetchFromDb } from "./fetch";
+
+export type UserAccount = {
+  dbId: number;
+  email: string;
+  password: string;
+};
+
+export async function tryGetUser(email: string, password: string) {
+  const usersResponse = await fetchFromDb("users");
+  if (!usersResponse.ok) {
+    console.error("Could not get users data");
+    return undefined;
+  }
+  const usersJson = await usersResponse.json();
+  const userEntries: UserAccount[] = usersJson.map((json: any) => {
+    const entry: UserAccount = {
+      dbId: json.id,
+      email: json.email,
+      password: json.password,
+    };
+    return entry;
+  });
+  const matchingUser = userEntries.find(
+    (entry) => entry.email === email && entry.password === password
+  );
+  return matchingUser;
+}

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -30,7 +30,10 @@ export async function tryValidateUser(userId: number) {
   return true;
 }
 
-export async function tryGetUser(email: string, password: string) {
+export async function tryGetUser(
+  emailToMatch: string,
+  passwordToMatch?: string
+) {
   const usersResponse = await fetchFromDb("users");
   if (!usersResponse.ok) {
     console.error("Could not get users data");
@@ -46,7 +49,27 @@ export async function tryGetUser(email: string, password: string) {
     return entry;
   });
   const matchingUser = userEntries.find(
-    (entry) => entry.email === email && entry.password === password
+    (entry) =>
+      entry.email === emailToMatch &&
+      (passwordToMatch === undefined || entry.password === passwordToMatch)
   );
   return matchingUser;
+}
+
+export async function tryCreateAccount(email: string, password: string) {
+  const postAccountJson = await postToDbAndReturnJson(
+    "users",
+    {
+      email,
+      password,
+    },
+    "Could not create account"
+  );
+  if (!postAccountJson) return undefined;
+  const account: UserAccount = {
+    dbId: postAccountJson.id,
+    email: postAccountJson.email,
+    password: postAccountJson.password,
+  };
+  return account;
 }

--- a/src/components/Account/CreateAccount/CreateAccount.tsx
+++ b/src/components/Account/CreateAccount/CreateAccount.tsx
@@ -46,6 +46,10 @@ export function CreateAccount() {
   }
 
   async function clickCreateAccount() {
+    const anyErrors = Object.values(inputErrors).find((value) => !!value);
+    if (anyErrors) {
+      return;
+    }
     const existingUser = await tryGetUser(email); //currently there's no way to distinguish between a server error and a missing user here
     if (existingUser) {
       setCreateAccountError("Could not create account.");

--- a/src/components/Account/CreateAccount/CreateAccount.tsx
+++ b/src/components/Account/CreateAccount/CreateAccount.tsx
@@ -1,37 +1,54 @@
 import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
 import { InputField } from "../../Common/InputField/InputField";
 
 export function CreateAccount() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
+  const navigate = useNavigate();
+
+  function tryCreateAccount() {
+    console.log("create account attempt");
+  }
 
   return (
-    <form
-      className="account-box"
-      onSubmit={(e) => {
-        e.preventDefault();
-      }}
-    >
-      <InputField
-        name="email"
-        labelText={"Email Address"}
-        value={email}
-        changeFunction={(e) => setEmail(e.target.value)}
-      />
-      <InputField
-        name="password"
-        labelText={"Password"}
-        value={password}
-        changeFunction={(e) => setPassword(e.target.value)}
-      />
-      <InputField
-        name="password-confirm"
-        labelText={"Confirm Password"}
-        value={passwordConfirm}
-        changeFunction={(e) => setPasswordConfirm(e.target.value)}
-      />
-      <button type="submit">Create Account</button>
-    </form>
+    <>
+      <form
+        className="account-box"
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+      >
+        <InputField
+          name="email"
+          labelText={"Email Address"}
+          value={email}
+          changeFunction={(e) => setEmail(e.target.value)}
+        />
+        <InputField
+          name="password"
+          labelText={"Password"}
+          value={password}
+          changeFunction={(e) => setPassword(e.target.value)}
+        />
+        <InputField
+          name="password-confirm"
+          labelText={"Confirm Password"}
+          value={passwordConfirm}
+          changeFunction={(e) => setPasswordConfirm(e.target.value)}
+        />
+        <button
+          type="submit"
+          onClick={(e) => {
+            e.preventDefault();
+            tryCreateAccount();
+          }}
+        >
+          Create Account
+        </button>
+      </form>
+      <Link to="/">Sign In</Link>
+    </>
   );
 }

--- a/src/components/Account/CreateAccount/CreateAccount.tsx
+++ b/src/components/Account/CreateAccount/CreateAccount.tsx
@@ -15,14 +15,6 @@ import {
 import { useAccount } from "../../AccountProvider";
 import { InputField } from "../../Common/InputField/InputField";
 
-type OptionalString = string | undefined;
-
-type InputErrors = {
-  email: OptionalString;
-  password: OptionalString;
-  passwordConfirm: OptionalString;
-};
-
 export function CreateAccount() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
@@ -73,6 +65,30 @@ export function CreateAccount() {
     navigate("/chart");
   }
 
+  const fields: InputField[] = [
+    {
+      name: "email",
+      labelText: "Email Address",
+      value: email,
+      errorText: inputErrors.email,
+      changeFunction: setEmail,
+    },
+    {
+      name: "password",
+      labelText: "Password",
+      value: password,
+      errorText: inputErrors.password,
+      changeFunction: setPassword,
+    },
+    {
+      name: "passwordConfirm",
+      labelText: "Confirm Password",
+      value: passwordConfirm,
+      errorText: inputErrors.passwordConfirm,
+      changeFunction: setPasswordConfirm,
+    },
+  ];
+
   return (
     <>
       <form
@@ -81,30 +97,16 @@ export function CreateAccount() {
           e.preventDefault();
         }}
       >
-        <InputField
-          name="email"
-          labelText={"Email Address"}
-          value={email}
-          errorText={inputErrors.email}
-          changeFunction={(e) => setEmail(e.target.value)}
-          blurFunction={(e) => blurField(e)}
-        />
-        <InputField
-          name="password"
-          labelText={"Password"}
-          value={password}
-          errorText={inputErrors.password}
-          changeFunction={(e) => setPassword(e.target.value)}
-          blurFunction={(e) => blurField(e)}
-        />
-        <InputField
-          name="passwordConfirm"
-          labelText={"Confirm Password"}
-          value={passwordConfirm}
-          errorText={inputErrors.passwordConfirm}
-          changeFunction={(e) => setPasswordConfirm(e.target.value)}
-          blurFunction={(e) => blurField(e)}
-        />
+        {fields.map((field) => (
+          <InputField
+            name={field.name}
+            labelText={field.labelText}
+            value={field.value}
+            errorText={field.errorText}
+            changeFunction={(e) => field.changeFunction(e.target.value)}
+            blurFunction={(e) => blurField(e)}
+          />
+        ))}
         {createAccountError.length > 0 && (
           <div className="error-text">{createAccountError}</div>
         )}

--- a/src/components/Account/CreateAccount/CreateAccount.tsx
+++ b/src/components/Account/CreateAccount/CreateAccount.tsx
@@ -1,15 +1,39 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
+import {
+  tryCreateAccount,
+  tryGetUser,
+  tryValidateUser,
+} from "../../../accounts";
+import { useAccount } from "../../AccountProvider";
 import { InputField } from "../../Common/InputField/InputField";
 
 export function CreateAccount() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [passwordConfirm, setPasswordConfirm] = useState("");
+  const [createAccountError, setCreateAccountError] = useState("");
   const navigate = useNavigate();
+  const { setActiveUser } = useAccount();
 
-  function tryCreateAccount() {
-    console.log("create account attempt");
+  async function clickCreateAccount() {
+    const existingUser = await tryGetUser(email); //currently there's no way to distinguish between a server error and a missing user here
+    if (existingUser) {
+      setCreateAccountError("Could not create account.");
+      return;
+    }
+    const createdAccount = await tryCreateAccount(email, password);
+    if (!createdAccount) {
+      setCreateAccountError("Could not create account.");
+      return;
+    }
+    const validated = await tryValidateUser(createdAccount.dbId);
+    if (!validated) {
+      setCreateAccountError("Could not create account.");
+      return;
+    }
+    setActiveUser(createdAccount);
+    navigate("/chart");
   }
 
   return (
@@ -38,11 +62,14 @@ export function CreateAccount() {
           value={passwordConfirm}
           changeFunction={(e) => setPasswordConfirm(e.target.value)}
         />
+        {createAccountError.length > 0 && (
+          <div className="error-text">{createAccountError}</div>
+        )}
         <button
           type="submit"
           onClick={(e) => {
             e.preventDefault();
-            tryCreateAccount();
+            clickCreateAccount();
           }}
         >
           Create Account

--- a/src/components/Account/SignIn/SignIn.tsx
+++ b/src/components/Account/SignIn/SignIn.tsx
@@ -27,6 +27,21 @@ export function SignIn() {
     }
   }
 
+  const fields: InputField[] = [
+    {
+      name: "email",
+      labelText: "Email Address",
+      value: email,
+      changeFunction: setEmail,
+    },
+    {
+      name: "password",
+      labelText: "Password",
+      value: password,
+      changeFunction: setPassword,
+    },
+  ];
+
   return (
     <>
       <form
@@ -35,18 +50,15 @@ export function SignIn() {
           e.preventDefault();
         }}
       >
-        <InputField
-          name="email"
-          labelText="Email Address"
-          value={email}
-          changeFunction={(e) => setEmail(e.target.value)}
-        />
-        <InputField
-          name="password"
-          labelText="Password"
-          value={password}
-          changeFunction={(e) => setPassword(e.target.value)}
-        />
+        {fields.map((field) => (
+          <InputField
+            name={field.name}
+            labelText={field.labelText}
+            value={field.value}
+            errorText={field.errorText}
+            changeFunction={(e) => field.changeFunction(e.target.value)}
+          />
+        ))}
         {signInError.length > 0 && (
           <div className="error-text">{signInError}</div>
         )}

--- a/src/components/Account/SignIn/SignIn.tsx
+++ b/src/components/Account/SignIn/SignIn.tsx
@@ -1,29 +1,47 @@
 import { useState } from "react";
+import { useNavigate, Link } from "react-router-dom";
 import { InputField } from "../../Common/InputField/InputField";
 
 export function SignIn() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const navigate = useNavigate();
+
+  function trySignIn() {
+    console.log("sign in attempt");
+  }
+
   return (
-    <form
-      className="account-box"
-      onSubmit={(e) => {
-        e.preventDefault();
-      }}
-    >
-      <InputField
-        name="email"
-        labelText="Email Address"
-        value={email}
-        changeFunction={(e) => setEmail(e.target.value)}
-      />
-      <InputField
-        name="password"
-        labelText="Password"
-        value={password}
-        changeFunction={(e) => setPassword(e.target.value)}
-      />
-      <button type="submit">Sign In</button>
-    </form>
+    <>
+      <form
+        className="account-box"
+        onSubmit={(e) => {
+          e.preventDefault();
+        }}
+      >
+        <InputField
+          name="email"
+          labelText="Email Address"
+          value={email}
+          changeFunction={(e) => setEmail(e.target.value)}
+        />
+        <InputField
+          name="password"
+          labelText="Password"
+          value={password}
+          changeFunction={(e) => setPassword(e.target.value)}
+        />
+        <button
+          type="submit"
+          onClick={(e) => {
+            e.preventDefault();
+            trySignIn();
+          }}
+        >
+          Sign In
+        </button>
+      </form>
+      <Link to="/createAccount">Create Account</Link>
+    </>
   );
 }

--- a/src/components/Account/SignIn/SignIn.tsx
+++ b/src/components/Account/SignIn/SignIn.tsx
@@ -7,6 +7,7 @@ import { InputField } from "../../Common/InputField/InputField";
 export function SignIn() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [signInError, setSignInError] = useState("");
   const navigate = useNavigate();
   const { setActiveUser } = useAccount();
 
@@ -15,11 +16,14 @@ export function SignIn() {
     if (user) {
       const validated = await tryValidateUser(user.dbId);
       if (!validated) {
-        console.error("Could not sign in, try again later");
+        setSignInError("Something went wrong. Try again later.");
         return;
       }
+      setSignInError("");
       setActiveUser(user);
       navigate("/chart");
+    } else {
+      setSignInError("Invalid username or password.");
     }
   }
 
@@ -43,6 +47,9 @@ export function SignIn() {
           value={password}
           changeFunction={(e) => setPassword(e.target.value)}
         />
+        {signInError.length > 0 && (
+          <div className="error-text">{signInError}</div>
+        )}
         <button
           type="submit"
           onClick={(e) => {

--- a/src/components/Account/SignIn/SignIn.tsx
+++ b/src/components/Account/SignIn/SignIn.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
-import { tryGetUser } from "../../../accounts";
+import { tryGetUser, tryValidateUser } from "../../../accounts";
 import { useAccount } from "../../AccountProvider";
 import { InputField } from "../../Common/InputField/InputField";
 
@@ -13,6 +13,11 @@ export function SignIn() {
   async function trySignIn() {
     const user = await tryGetUser(email, password);
     if (user) {
+      const validated = await tryValidateUser(user.dbId);
+      if (!validated) {
+        console.error("Could not sign in, try again later");
+        return;
+      }
       setActiveUser(user);
       navigate("/chart");
     }

--- a/src/components/Account/SignIn/SignIn.tsx
+++ b/src/components/Account/SignIn/SignIn.tsx
@@ -1,14 +1,21 @@
 import { useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
+import { tryGetUser } from "../../../accounts";
+import { useAccount } from "../../AccountProvider";
 import { InputField } from "../../Common/InputField/InputField";
 
 export function SignIn() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
+  const { setActiveUser } = useAccount();
 
-  function trySignIn() {
-    console.log("sign in attempt");
+  async function trySignIn() {
+    const user = await tryGetUser(email, password);
+    if (user) {
+      setActiveUser(user);
+      navigate("/chart");
+    }
   }
 
   return (

--- a/src/components/AccountProvider.tsx
+++ b/src/components/AccountProvider.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, useState, createContext, useContext } from "react";
+import { UserAccount } from "../accounts";
+
+type ChildrenProps = {
+  children: ReactNode;
+};
+
+type AccountContextType = {
+  activeUser: UserAccount;
+  setActiveUser: (user: UserAccount) => void;
+};
+
+const AccountContext = createContext({} as AccountContextType);
+
+export function useAccount() {
+  return useContext(AccountContext);
+}
+
+export function AccountProvider({ children }: ChildrenProps) {
+  const [activeUser, setActiveUser] = useState({} as UserAccount);
+
+  return (
+    <AccountContext.Provider value={{ activeUser, setActiveUser }}>
+      {children}
+    </AccountContext.Provider>
+  );
+}

--- a/src/components/Common/InputField/InputField.tsx
+++ b/src/components/Common/InputField/InputField.tsx
@@ -1,14 +1,23 @@
 type InputFieldProps = {
-  name: string,
-  id?: string,
-  value: any,
-  labelText?: string,
-  errorText?: string,
-  changeFunction?: (e: React.ChangeEvent<HTMLInputElement>) => void
-}
+  name: string;
+  id?: string;
+  value: any;
+  labelText?: string;
+  errorText?: string;
+  changeFunction?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  blurFunction?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+};
 
 export function InputField(props: InputFieldProps) {
-  const { errorText, labelText, name, id, value, changeFunction } = props;
+  const {
+    errorText,
+    labelText,
+    name,
+    id,
+    value,
+    changeFunction,
+    blurFunction,
+  } = props;
 
   return (
     <div className="input-field-container">
@@ -18,6 +27,7 @@ export function InputField(props: InputFieldProps) {
         name={name}
         id={id ? id : name}
         onChange={changeFunction}
+        onBlur={blurFunction}
       />
       {errorText && <div className="error-text">{errorText}</div>}
     </div>

--- a/src/components/DayChartProvider.tsx
+++ b/src/components/DayChartProvider.tsx
@@ -11,6 +11,7 @@ import {
   tryDeletePortion,
   updateDayChart,
 } from "../updateDayChart";
+import { useAccount } from "./AccountProvider";
 
 type DayChartContext = {
   dayChartData: DayChartData;
@@ -41,19 +42,23 @@ export function useDayChart() {
     setDayChart,
   } = useContext(DayChartContext);
 
-  async function addPortion(fdcId: number, fractionOfServing: number) {
+  async function addPortion(
+    userId: number,
+    fdcId: number,
+    fractionOfServing: number
+  ) {
     const added = await tryAddPortion(
       fdcId,
       fractionOfServing,
       clickedSectionIndex,
       dayChart
     );
-    if (added) updateDayChart(setDayChart, setIsLoading);
+    if (added) updateDayChart(userId, setDayChart, setIsLoading);
   }
 
-  async function deletePortion(portionId: number) {
+  async function deletePortion(userId: number, portionId: number) {
     const deleted = await tryDeletePortion(portionId);
-    if (deleted) updateDayChart(setDayChart, setIsLoading);
+    if (deleted) updateDayChart(userId, setDayChart, setIsLoading);
   }
 
   return {
@@ -75,9 +80,10 @@ export function DayChartProvider({ children }: ChildrenProps) {
   const [showSearch, setShowSearch] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [clickedSectionIndex, setClickedSectionIndex] = useState(0);
+  const { activeUser } = useAccount();
 
   useEffect(() => {
-    updateDayChart(setDayChart, setIsLoading);
+    updateDayChart(activeUser.dbId, setDayChart, setIsLoading);
   }, []);
 
   return (

--- a/src/components/Planner/DayChart/DayChart.tsx
+++ b/src/components/Planner/DayChart/DayChart.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import { daysToShow } from "../../../constants";
 import { LoadingIndicator } from "../../Common/LoadingIndicator/LoadingIndicator";
 import { useDayChart } from "../../DayChartProvider";
@@ -18,6 +19,7 @@ export function DayChart() {
       </div>
       {isLoading && <LoadingIndicator />}
       {showSearch && <FoodSearch />}
+      <Link to="/">Log Out</Link>
     </>
   );
 }

--- a/src/components/Planner/DayChart/DayChart.tsx
+++ b/src/components/Planner/DayChart/DayChart.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { daysToShow } from "../../../constants";
+import { useAccount } from "../../AccountProvider";
 import { LoadingIndicator } from "../../Common/LoadingIndicator/LoadingIndicator";
 import { useDayChart } from "../../DayChartProvider";
 import { FoodSearch } from "../../Search/FoodSearch/FoodSearch";
@@ -9,6 +10,7 @@ import "./DayChart.css";
 export function DayChart() {
   const { showSearch, isLoading } = useDayChart();
   const days = new Array(daysToShow).fill({});
+  const { activeUser } = useAccount();
 
   return (
     <>
@@ -20,6 +22,7 @@ export function DayChart() {
       {isLoading && <LoadingIndicator />}
       {showSearch && <FoodSearch />}
       <Link to="/">Log Out</Link>
+      <p>{activeUser.email}</p>
     </>
   );
 }

--- a/src/components/Planner/PortionRow/PortionRow.tsx
+++ b/src/components/Planner/PortionRow/PortionRow.tsx
@@ -3,6 +3,7 @@ import { unknownFoodName } from "../../../constants";
 import { useFakeData } from "../../../fakeData";
 import { fetchSingleFdcFoodJson } from "../../../fetch";
 import { PortionRowState } from "../../../types/DayChartTypes";
+import { useAccount } from "../../AccountProvider";
 import { useDayChart } from "../../DayChartProvider";
 import "./PortionRow.css";
 
@@ -12,14 +13,18 @@ type PortionRowProps = {
 
 export function PortionRow(props: PortionRowProps) {
   const {
-    row: { dbId, fdcId, foodData },
+    row: { dbId: rowId, fdcId, foodData },
   } = props;
   const { deletePortion } = useDayChart();
+  const { activeUser } = useAccount();
 
   return (
     <div className="portion-row">
       <div>{foodData.description}</div>
-      <button className="button-x" onClick={() => deletePortion(dbId)}>
+      <button
+        className="button-x"
+        onClick={() => deletePortion(activeUser.dbId, rowId)}
+      >
         X
       </button>
     </div>

--- a/src/components/Search/FoodSearch/FoodSearch.tsx
+++ b/src/components/Search/FoodSearch/FoodSearch.tsx
@@ -3,6 +3,7 @@ import { API_KEY, API_URL } from "../../../constants";
 import { fakeSearch, useFakeData } from "../../../fakeData";
 import { searchFdcFoodsJson } from "../../../fetch";
 import { FoodSearchJson } from "../../../types/FoodDataTypes";
+import { useAccount } from "../../AccountProvider";
 import { useDayChart } from "../../DayChartProvider";
 import { FoodSearchResult } from "../FoodSearchResult/FoodSearchResult";
 import "./FoodSearch.css";
@@ -12,6 +13,7 @@ export function FoodSearch() {
   const [searchResults, setSearchResults] = useState({} as FoodSearchJson);
   const [selectedFdcId, setSelectedFdcId] = useState(0);
   const { addPortion } = useDayChart();
+  const { activeUser } = useAccount();
 
   async function search() {
     if (useFakeData) {
@@ -24,7 +26,7 @@ export function FoodSearch() {
 
   function clickAdd() {
     setShowSearch(false);
-    addPortion(selectedFdcId, 1);
+    addPortion(activeUser.dbId, selectedFdcId, 1);
   }
 
   function selectFood(fdcId: number) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,15 +1,19 @@
 import { API_KEY, API_URL, DB_URL } from "./constants";
 import {
   DayChartDayEntry,
+  DayChartEntry,
   DaySectionEntry,
   DaySectionRowEntry,
   PortionRowEntry,
+  UserDayChartEntry,
 } from "./types/DayChartTypes";
 import { splitArrayBy } from "./utility";
 
 const foodDataCache = new Map();
 
 export type EndpointJsons = {
+  userDayCharts: UserDayChartEntry[];
+  dayCharts: DayChartEntry[];
   dayChartDays: DayChartDayEntry[];
   daySections: DaySectionEntry[];
   daySectionRows: DaySectionRowEntry[];
@@ -18,6 +22,8 @@ export type EndpointJsons = {
 
 export async function fetchEndpointJsons() {
   const endpoints = [
+    "userDayCharts",
+    "dayCharts",
     "dayChartDays",
     "daySections",
     "daySectionRows",
@@ -28,10 +34,12 @@ export async function fetchEndpointJsons() {
   );
   const jsons = await Promise.all(responses.map((response) => response.json()));
   const result: EndpointJsons = {
-    dayChartDays: jsons[0],
-    daySections: jsons[1],
-    daySectionRows: jsons[2],
-    portionRows: jsons[3],
+    userDayCharts: jsons[0],
+    dayCharts: jsons[1],
+    dayChartDays: jsons[2],
+    daySections: jsons[3],
+    daySectionRows: jsons[4],
+    portionRows: jsons[5],
   };
   return result;
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/types/DayChartTypes.ts
+++ b/src/types/DayChartTypes.ts
@@ -24,6 +24,13 @@ export type DayChartDayEntry = DBEntry & {
   indexInChart: number;
 };
 
+export type DayChartEntry = DBEntry & {};
+
+export type UserDayChartEntry = DBEntry & {
+  userId: number;
+  dayChartId: number;
+};
+
 export type DayChartData = {
   dayChartDays: DayChartDayEntry[];
   daySections: DaySectionEntry[];

--- a/src/types/InputFieldTypes.ts
+++ b/src/types/InputFieldTypes.ts
@@ -1,0 +1,15 @@
+type OptionalString = string | undefined;
+
+type InputErrors = {
+  email: OptionalString;
+  password: OptionalString;
+  passwordConfirm: OptionalString;
+};
+
+type InputField = {
+  name: string;
+  labelText: string;
+  value: string;
+  errorText?: string;
+  changeFunction: (value: string) => void;
+};

--- a/src/updateDayChart.ts
+++ b/src/updateDayChart.ts
@@ -1,3 +1,4 @@
+import { useAccount } from "./components/AccountProvider";
 import { daysToShow, sectionsPerDay, unknownFoodName } from "./constants";
 import { fakeSingleFoods, useFakeData } from "./fakeData";
 import {
@@ -9,17 +10,20 @@ import {
 } from "./fetch";
 import {
   DayChartDayEntry,
+  DayChartEntry,
   DayChartState,
   DaySectionEntry,
   DaySectionRowEntry,
   DayState,
   PortionRowEntry,
   PortionRowState,
+  UserDayChartEntry,
 } from "./types/DayChartTypes";
 import { FoodData } from "./types/FoodDataTypes";
 import { extractFoodDataFromJson } from "./utility";
 
 export async function updateDayChart(
+  userId: number,
   setDayChart: (state: DayChartState) => void,
   setIsLoading: (b: boolean) => void
 ) {
@@ -31,7 +35,7 @@ export async function updateDayChart(
   );
   if (useFakeData) {
     const fakeData = getAllFakeFoodData(fdcIds);
-    const dayChart = buildDayChartState(endpointJsons, fakeData);
+    const dayChart = buildDayChartState(endpointJsons, userId, fakeData);
     setDayChart(dayChart);
     return;
   }
@@ -41,6 +45,7 @@ export async function updateDayChart(
 
   const dayChart: DayChartState = buildDayChartState(
     endpointJsons,
+    userId,
     allFoodData
   );
 
@@ -69,37 +74,58 @@ function getAllFakeFoodData(fdcIds: number[]): FoodData[] {
 
 function buildDayChartState(
   endpointJsons: EndpointJsons,
+  userId: number,
   allFoodData: FoodData[]
 ): DayChartState {
+  const { userDayCharts, dayCharts } = endpointJsons;
+  const userDayChartPairFromDb = userDayCharts.find(
+    (pair: UserDayChartEntry) => pair.userId === userId
+  );
+  const dayChartFromDb = dayCharts.find(
+    (dayChart: DayChartEntry) =>
+      dayChart.id === userDayChartPairFromDb?.dayChartId
+  );
   return {
     dayChartId: 1,
-    days: Array.from({ length: daysToShow }, (_, dayIndex) =>
-      buildDay(dayIndex, endpointJsons, allFoodData)
+    days: Array.from(
+      { length: daysToShow },
+      (_, dayIndex) =>
+        dayChartFromDb &&
+        buildDay(dayChartFromDb.id, dayIndex, endpointJsons, allFoodData)
     ),
   };
 }
 
 function buildDay(
+  dayChartId: number,
   indexInChart: number,
   endpointJsons: EndpointJsons,
   allFoodData: FoodData[]
 ) {
   const dayFromDb = endpointJsons.dayChartDays.find(
     (dayChartDay) =>
-      dayChartDay.dayChartId === 1 && dayChartDay.indexInChart === indexInChart
+      dayChartDay.dayChartId === dayChartId &&
+      dayChartDay.indexInChart === indexInChart
   );
   const day: DayState | undefined = dayFromDb && {
     dbId: dayFromDb.id,
-    dayChartId: 1,
+    dayChartId,
     indexInChart,
     sections: Array.from({ length: sectionsPerDay }, (_, sectionIndex) =>
-      buildSection(indexInChart, sectionIndex, endpointJsons, allFoodData)
+      buildSection(
+        dayChartId,
+        indexInChart,
+        sectionIndex,
+        endpointJsons,
+        allFoodData
+      )
     ),
   };
   return day;
 }
 
 function buildSection(
+  dayChartId: number,
   dayIndex: number,
   indexInDay: number,
   endpointJsons: EndpointJsons,
@@ -110,7 +136,8 @@ function buildSection(
 
   const dayFromDb = dayChartDays.find(
     (dayChartDay: DayChartDayEntry) =>
-      dayChartDay.dayChartId === 1 && dayChartDay.indexInChart === dayIndex
+      dayChartDay.dayChartId === dayChartId &&
+      dayChartDay.indexInChart === dayIndex
   );
   const sectionFromDb =
     dayFromDb &&

--- a/src/updateDayChart.ts
+++ b/src/updateDayChart.ts
@@ -43,6 +43,7 @@ export async function updateDayChart(
   const allFoodData = await getAllFoodData(fdcIds);
   if (!allFoodData) return;
 
+  // const dayChartId = await tryGetDayChartId(userId, endpointJsons);
   const dayChart: DayChartState = buildDayChartState(
     endpointJsons,
     userId,
@@ -85,13 +86,11 @@ function buildDayChartState(
     (dayChart: DayChartEntry) =>
       dayChart.id === userDayChartPairFromDb?.dayChartId
   );
+  const dayChartId = dayChartFromDb ? dayChartFromDb.id : 0;
   return {
-    dayChartId: 1,
-    days: Array.from(
-      { length: daysToShow },
-      (_, dayIndex) =>
-        dayChartFromDb &&
-        buildDay(dayChartFromDb.id, dayIndex, endpointJsons, allFoodData)
+    dayChartId,
+    days: Array.from({ length: daysToShow }, (_, dayIndex) =>
+      buildDay(dayChartId, dayIndex, endpointJsons, allFoodData)
     ),
   };
 }
@@ -230,7 +229,7 @@ export async function tryAddPortion(
     const postJson = await postToDbAndReturnJson(
       "dayChartDays",
       {
-        dayChartId: 1,
+        dayChartId: dayChart.dayChartId,
         indexInChart: clickedDayIndex,
       },
       "Could not add new day"

--- a/src/validations.ts
+++ b/src/validations.ts
@@ -1,0 +1,20 @@
+export const checkValidEmail = (input: string) =>
+  /^(?:[a-zA-Z\d]+)@(?:[a-zA-Z\d]+)\.(?:[a-zA-Z]{2,})$/g.test(input);
+export const checkValidPassword = (input: string) =>
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*()_+]).{8,20}$/g.test(input);
+
+export const validPasswordMessage =
+  "Password must be 8-20 characters, including at least one capital letter, at least one small letter, one number and one special character - !@#$%^&*()_+";
+export const provideEmailMessage = "Please provide a valid email.";
+export const matchPasswordsMessage = "The passwords must match.";
+
+// type StringKeyObj = {
+//   [key: string]: any
+// }
+
+// export const inputValidationFunctions: StringKeyObj = {
+//   email: (email: string) =>
+//     !checkValidEmail(email) ? provideEmailMessage : undefined,
+//   password: (password: string) =>
+//     !checkValidPassword(password) ? validPasswordMessage : undefined,
+// };


### PR DESCRIPTION
Creating and signing into accounts is now supported. 

User can input email and password in the sign in form. If there is any user entry in db.json with the same email and password as those entered, sign in succeeds and the app navigates to the chart, with the user's account set as active.

User can input account creation details in the create account form. The fields perform validation when they lose focus. Account creation fails if any field is invalid, if a user with the same email already exists, or if there is some problem reaching the local server. Otherwise, it succeeds. On success, the app navigates to the chart, with the user's account set as active (the same behavior as signing in).

Data is unique to each user. Only the active user's dayChart is loaded and displayed, and they can only add/delete data from that dayChart.

React Router has also been added to facilitate navigation between sign in, account creation, and the chart.